### PR TITLE
Added 'play card' feature to stats tab

### DIFF
--- a/lotrdb.js
+++ b/lotrdb.js
@@ -991,6 +991,10 @@
     this.draw = function() {
       this.hand.push(this.deck.pop());
     }
+
+    this.playCard = function(handIndex) {
+      this.hand.splice(handIndex, 1);
+    }
     
     this.sphereSplit = function() {
       this.reloadDeck();

--- a/stats.html
+++ b/stats.html
@@ -7,7 +7,10 @@
     <button ng-click="stats.draw()">Draw</button>
     <br/><br/>
     <ul>
-      <li ng-repeat="card in stats.hand track by $index" ng-mouseover="deckC.changepreview(card)" class="card c{{card.sphere}}">{{card.name}}</li>
+      <li ng-repeat="card in stats.hand track by $index" ng-mouseover="deckC.changepreview(card)" class="card c{{card.sphere}}">
+        {{card.name}}
+        <span ng-click="stats.playCard($index)">Play Card</span>
+      </li>
     </ul>
   </div>
   

--- a/style.css
+++ b/style.css
@@ -315,6 +315,19 @@ margin-bottom:2px;
   border-color: #555 #eee #eee #555;
 }
 
+.carddraw li span {
+  color: #337ab7;
+  font-size: 11px;
+  float: right;
+  line-height: 1.8;
+  cursor: pointer;
+  margin-right: 4px;
+  display: none;
+}
+.carddraw li:hover span {
+  display: inline-block;
+}
+
 
 
 .mydecks{


### PR DESCRIPTION
Added a 'Play Card' feature to the stats page

When a user is testing their deck with the "Start" and "Draw" buttons on the Stats tab, it can be useful for a player wanting to visualize the first few rounds of a game to remove cards from their hand to simulate the act of playing them. This can allow a user to have a better idea of what their hand might look like a few rounds into a game.

Now, when a user hovers over a card in their hand, they will see a "Play Card" link. Clicking this will simply remove the card from their hand.

Please let me know if any thoughts/concerns