### PR TITLE
Added Across the Ettenmoores to the Select All button on the Packs tab

### DIFF
--- a/lotrdb.js
+++ b/lotrdb.js
@@ -42,7 +42,7 @@
   //Logic for the pack selection
   app.controller('packSelect',["filtersettings","$localStorage",function(filtersettings,$localStorage){
     this.filtersettings=filtersettings;
-    this.full=["core", "kd", "hon", "voi", "tlr", "thohauh", "thfg", "trg", "tsf", "tdt", "twoe", "thotd", "catc", "rtr", "tdf", "ttt", "efmg", "tbr", "ajtr", "twitw", "eaad", "tit", "rd", "thoem", "tld", "aoo", "nie", "tdm", "fos", "tbog", "cs", "rtm", "saf", "tmv", "tac", "tos", "tlos"]; //all expansions so far
+    this.full=["core", "kd", "hon", "voi", "tlr", "thohauh", "thfg", "trg", "tsf", "tdt", "twoe", "thotd", "catc", "rtr", "tdf", "ttt", "efmg", "tbr", "ajtr", "twitw", "eaad", "tit", "rd", "thoem", "tld", "aoo", "nie", "tdm", "fos", "tbog", "cs", "rtm", "saf", "tmv", "tac", "tos", "tlos", "ate"]; //all expansions so far
     this.toggle=function(exp){
       var ind = this.filtersettings.pack.indexOf(exp);
       if (ind<0) { //index will be -1 if not found


### PR DESCRIPTION
As the title suggests, currently all packs except ATE get chosen when pressing "Select All". This PR fixes that.