### PR TITLE
Add 15px margin to bottom of deck and card tables

### DIFF
--- a/style.css
+++ b/style.css
@@ -175,6 +175,7 @@ h3 {
 
 table.cardlist {
   width:100%;
+  margin-bottom: 15px;
 }
 
 
@@ -196,7 +197,7 @@ table.cardlist {
 
 table.deck {
   padding:0;
-  margin: 0;
+  margin: 0 0 15px 0;
   width: 100%
 }
 


### PR DESCRIPTION
Minor usability tweak for issue that was bugging me. Makes it a little easier to click cards at bottom of lists, it no longer looks like the lists might be getting cut off! (I actually thought it wasn't showing my entire deck for a while.)

Love this project, use it every day!